### PR TITLE
Enable cross-account copy by leaving the default owner

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import boto3
+import botocore
+import json
 
 # Use whatever you have configured
 #aws = boto3.Session(profile_name='')
@@ -21,22 +23,37 @@ pages = paginator.paginate(Bucket=s3_bucket_src)
 for page in pages:
     for obj in page['Contents']:
         object_key = obj['Key']
-        object_acl = s3.get_object_acl(Bucket=s3_bucket_src, Key=object_key)
-        print(obj['Key'])
+        try:
+             s3.get_object_acl(Bucket=s3_bucket_dest, Key=object_key)
+        except botocore.exceptions.ClientError:
+            s3.copy_object(
+                Bucket=s3_bucket_dest,
+                CopySource={
+                    'Bucket': s3_bucket_src,
+                    'Key': object_key
+                },
+                Key=object_key
+            )
 
-        s3.copy_object(
-            Bucket=s3_bucket_dest,
-            CopySource={
-                'Bucket': s3_bucket_src,
-                'Key': object_key
-            },
-            Key=object_key
-        )
+        try:
+            object_acl = s3.get_object_acl(Bucket=s3_bucket_src, Key=object_key)
+        except botocore.exceptions.ClientError:
+            continue
+
+        if len(object_acl['Grants']) == 1:
+            continue
+
+        target_acl = s3.get_object_acl(Bucket=s3_bucket_dest, Key=object_key)
+        if len(object_acl['Grants']) <= len(target_acl['Grants']):
+            continue
+
+        target_acl['Grants'] += object_acl['Grants'][1:]
+
         data = {
             'AccessControlPolicy': {
-                'Owner': object_acl['Owner'],
-                'Grants': object_acl['Grants']
+                'Owner': target_acl['Owner'],
+                'Grants': target_acl['Grants']
             }
         }
-        print(data)
+        print(object_key)
         s3.put_object_acl(**data, Bucket=s3_bucket_dest, Key=object_key)


### PR DESCRIPTION
Not sure if this is in your interest. 

Enable cross-account copy by leaving the default owner. Only copy objects if key does not exist on target. Only add extra Grants on top of the FULLACCESS Grant to the owner. Skip target files which have the same amount or more grants.